### PR TITLE
Fix typo add validation

### DIFF
--- a/crawler/crawler.py
+++ b/crawler/crawler.py
@@ -46,7 +46,7 @@ class Crawler:
     def add_members(self):
         if (self.is_org()):
           pass
-        else
+        else:
           print "%s is not a GitHub organization" % (self.org)
           sys.exit(0)
 

--- a/scanner/contributions.py
+++ b/scanner/contributions.py
@@ -35,9 +35,10 @@ def contributions(time_series, start, reference='organization'):
 
     for i in range(len(time_series)):
         time_str = time_series[i]['repository_pushed_at'].split(" ")[0]
- 
-        index = time_data.index(time_str)
-        commit_data[index] += 1
+
+        if time_str in time_data:
+            index = time_data.index(time_str)
+            commit_data[index] += 1
 
     contributions = []
     for i in range(366):


### PR DESCRIPTION
Fix typo in crawler causing:

``` bash
➜  teamwork git:(master) ✗ ./crawl
Traceback (most recent call last):
  File "./crawl", line 9, in <module>
    from crawler.crawler import Crawler
  File "/Users/emmanueldelgado/Projects/teamwork/crawler/crawler.py", line 49
    else
       ^
SyntaxError: invalid syntax
```

Verify that the time_str exists before looking it up in the list, it was causing:

``` bash
➜  teamwork git:(master) ✗ ./scan
Traceback (most recent call last):
  File "./scan", line 82, in <module>
    main()
  File "./scan", line 73, in main
    organization_contributions(driver)
  File "./scan", line 25, in organization_contributions
    org_data = contributions.contributions(time_series, start, 'organization')
  File "/Users/emmanueldelgao/Projects/teamwork/scanner/contributions.py", line 39, in contributions
    index = time_data.index(time_str)
ValueError: u'2014-03-21' is not in list
```
